### PR TITLE
Mime-Type saved as commit message

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "semistandard": "^17.0.0"
   },
   "scripts": {
-    "test": "mocha --recursive src --timeout 30000",
+    "test": "mocha --recursive src --timeout 40000",
     "lint": "semistandard --fix"
   }
 }

--- a/src/database.test.js
+++ b/src/database.test.js
@@ -52,6 +52,10 @@ describe('Testing database', () => {
     assert.rejects(kv.increment(key, -4), { message: 'Old value must be a Number' });
     assert.rejects(kv.toggle(key), { message: 'Old value must be a Boolean' });
 
+    const blob = new Blob(['hello', 'world'], { type: 'custom/mime' });
+    await kv.create(key, blob, { overwrite: true });
+    assert.deepStrictEqual(await kv.read(key), blob);
+
     await kv.create(key, 3, { overwrite: true });
     await kv.increment(key, -4);
     assert.deepStrictEqual(await kv.read(key), -1);

--- a/src/database.test.js
+++ b/src/database.test.js
@@ -65,6 +65,7 @@ describe('Testing database', () => {
     assert.deepStrictEqual(await kv.read(key), true);
 
     await kv.delete([key]);
+    assert.deepStrictEqual(await kv.has(key), false);
     assert.deepStrictEqual(await kv.read(key), undefined);
   });
 });

--- a/src/github.js
+++ b/src/github.js
@@ -296,6 +296,22 @@ export default class Repository {
     throw new Error('Unexpected failure with CDNs');
   }
 
+  // Params: commitHash <string>
+  // Returns: <String> | undefined, if commit doesn't exist
+  async fetchCommitMessage (commitHash) {
+    return this.request('HEAD /repos/{owner}/{repo}/git/commits/{ref}', {
+      ref: commitHash
+    })
+      .then((response) => response.data.message)
+      .catch((err) => {
+        if (err.status === 404) {
+          return;
+        } else {
+          throw err;
+        }
+      });
+  }
+
   // Brief: Returns CDN URLs for viewing content for the provided commit
   // Params: commitHash <string>
   cdnLinks (commitHash) {


### PR DESCRIPTION
Blob MIME Types are saved as commit messages in plain text (i.e. unencrypted). Only the Blob contents, i.e. its bytes, are stored in a git-blob. This ensures duplicate MIME types such as `image/jpeg | image/pjpeg` or `text/javascript | application/javascript` can share the same git-blob, thus aiding deduplication.